### PR TITLE
Silence errors about your Gemfile

### DIFF
--- a/plugin/tags.vim
+++ b/plugin/tags.vim
@@ -290,7 +290,7 @@ fun! s:generate_tags(bang, redraw)
 
     " check if bundle works fine
     if s:gemfile_correctness.time != gemfile_time
-      silent! exe '!bundle check'
+      silent! exe '!bundle check &>/dev/null'
       let s:gemfile_correctness.error = v:shell_error
       let s:gemfile_correctness.time  = gemfile_time
     endif


### PR DESCRIPTION
If you have warnings or errors from the output of `bundle check` it writes them to the status line in vim and generally messes up, requiring a redraw.

Since we only care about the error code (is this true?) we can redirect all output to `/dev/null`