### PR TITLE
use absolute path for tags option

### DIFF
--- a/plugin/tags.vim
+++ b/plugin/tags.vim
@@ -114,13 +114,18 @@ endfunction
 function s:add_tags_location(location)
   let location = substitute(a:location, '^\./', '', '')
 
-  if exists("s:locations[location]")
+  let abs_location = fnamemodify(a:location, ":p")
+  let tags_list = split(&tags, ',')
+  if index(tags_list, abs_location) != -1
     return
   endif
 
-  silent! exe 'set tags+=' . location
-  let s:locations[location] = 1
-  let s:dirty_locations = 1
+  silent! exe 'setlocal tags+=' . abs_location
+
+  if !exists("s:locations[location]")
+    let s:locations[location] = 1
+    let s:dirty_locations = 1
+  endif
 endfunction
 
 function! s:generate_options()

--- a/plugin/tags.vim
+++ b/plugin/tags.vim
@@ -327,5 +327,5 @@ fun! s:generate_tags(bang, redraw)
 endfun
 
 if g:vim_tags_auto_generate
-  au BufWritePost * call s:generate_tags(0, 0)
+  au BufEnter,BufWritePost * call s:generate_tags(0, 0)
 endif


### PR DESCRIPTION
If I set `acd` option, I sometimes encountered ''No tags file" error. I see the `tags` option value and find it use relative path such as `.git/tags`, but what I need is `project_root/.git/tags`.  And when I first open a file and do not write anything, `generate_tags` will not execute so `tags` option may not contain right path. So I add `BufEnter` event.

Also I think use tags cache file may be not a good idea (but I don't change it now), because sometimes I don't want to have a huge `tags` path (with many unrelevant project tags path) and what I need is only one `+=project_root/.git/tags`.

Finally I think `setlocal` is better than `set`.