### PR TITLE
Replace tag files only after an updated version has been created.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The Vim-Tags available variables are:
 
     This command is used for main Ctags generation.
 
-        let g:vim_tags_project_tags_command = "{CTAGS} -R {OPTIONS} {DIRECTORY} 2>/dev/null"
+        let g:vim_tags_project_tags_command = "({CTAGS} -R {OPTIONS} {DIRECTORY} 2>/dev/null) \&\& ({PLACE_TAGS})"
 
 
 * `vim_tags_gems_tags_command`

--- a/doc/vim-tags.txt
+++ b/doc/vim-tags.txt
@@ -135,7 +135,7 @@ Default: "{CTAGS} -R {OPTIONS} {DIRECTORY} 2>/dev/null"
 
 This command is used for main Ctags generation. >
 
-    let g:vim_tags_project_tags_command = "{CTAGS} -R {OPTIONS} {DIRECTORY} 2>/dev/null"
+    let g:vim_tags_project_tags_command = "({CTAGS} -R {OPTIONS} {DIRECTORY} 2>/dev/null) \&\& ({PLACE_TAGS})"
 <
 
 *vim_tags_gems_tags_command*


### PR DESCRIPTION
I've noticed that on larger files I'll see a 'no such tags' file after saving a file b/c vim-tags is generating a new copy of the ctags file. This change leaves the ctags in place, allowing it to be used while the new one is generated.